### PR TITLE
display DIDs as links on credential pages

### DIFF
--- a/identity-enabler/deviceId-mobile-app/src/components/ObjectList.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/components/ObjectList.svelte
@@ -1,4 +1,5 @@
 <script>
+    import { IOTA_IDENTITY_RESOLVER } from "../config";
     import { flattenObj } from "../lib/helpers";
 
     export let object;
@@ -8,7 +9,16 @@
     {#each Object.entries(flattenObj(object)) as entry}
         <li>
             <p>{entry[0].split(".").pop()}</p>
-            <span class="cut-text">{entry[1]}</span>
+            {#if entry[1]?.startsWith("did:iota:")}
+                <a
+                    class="cut-text"
+                    href={`${IOTA_IDENTITY_RESOLVER}/${entry[1]}`}
+                    target="_blank"
+                    title="View in IOTA Explorer">{entry[1]}</a
+                >
+            {:else}
+                <span class="cut-text">{entry[1]}</span>
+            {/if}
         </li>
     {/each}
 </ul>
@@ -49,7 +59,8 @@
         margin: 0.43vh 0;
     }
 
-    li > span {
+    li > span,
+    li > a {
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
         font-size: 2vh;

--- a/identity-enabler/deviceId-mobile-app/src/components/ObjectList.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/components/ObjectList.svelte
@@ -9,7 +9,7 @@
     {#each Object.entries(flattenObj(object)) as entry}
         <li>
             <p>{entry[0].split(".").pop()}</p>
-            {#if entry[1]?.startsWith("did:iota:")}
+            {#if typeof entry[1] === "string" && entry[1].startsWith("did:iota:")}
                 <a
                     class="cut-text"
                     href={`${IOTA_IDENTITY_RESOLVER}/${entry[1]}`}

--- a/identity-enabler/deviceId-mobile-app/src/config.ts
+++ b/identity-enabler/deviceId-mobile-app/src/config.ts
@@ -15,3 +15,5 @@ export const TUTORIAL_BASE_URL = "https://jmcanterafonseca-iota.github.io/zebra-
 export const IDENTITY_WASM_PATH = "/wasm/identity_wasm_bg.wasm";
 
 export const BACK_BUTTON_EXIT_GRACE_PERIOD = 2000; // 2s is same duration as "short" Toast
+
+export const IOTA_IDENTITY_RESOLVER = "https://explorer.iota.org/mainnet/identity-resolver";

--- a/identity-enabler/deviceId-mobile-app/src/web/css/global.css
+++ b/identity-enabler/deviceId-mobile-app/src/web/css/global.css
@@ -135,3 +135,11 @@ i {
 .rotate-180 {
     transform: rotate(180deg);
 }
+
+/* 
+  Show a little arrow glyph after `target="_blank"` anchors.
+*/
+a[target="_blank"]:after {
+    content: " \2197";
+    font-size: 0.9em;
+}

--- a/identity-enabler/holder-mobile-app/src/components/ObjectList.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/ObjectList.svelte
@@ -1,4 +1,5 @@
 <script>
+    import { IOTA_IDENTITY_RESOLVER } from "../config";
     import { flattenObj } from "../lib/helpers";
 
     export let object;
@@ -8,7 +9,16 @@
     {#each Object.entries(flattenObj(object)) as entry}
         <li>
             <p>{entry[0].split(".").pop()}</p>
-            <span class="cut-text">{entry[1]}</span>
+            {#if entry[1]?.startsWith("did:iota:")}
+                <a
+                    class="cut-text"
+                    href={`${IOTA_IDENTITY_RESOLVER}/${entry[1]}`}
+                    target="_blank"
+                    title="View in IOTA Explorer">{entry[1]}</a
+                >
+            {:else}
+                <span class="cut-text">{entry[1]}</span>
+            {/if}
         </li>
     {/each}
 </ul>
@@ -48,7 +58,8 @@
         margin: 0.43vh 0;
     }
 
-    li > span {
+    li > span,
+    li > a {
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
         font-size: 2vh;

--- a/identity-enabler/holder-mobile-app/src/components/ObjectList.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/ObjectList.svelte
@@ -9,7 +9,7 @@
     {#each Object.entries(flattenObj(object)) as entry}
         <li>
             <p>{entry[0].split(".").pop()}</p>
-            {#if entry[1]?.startsWith("did:iota:")}
+            {#if typeof entry[1] === "string" && entry[1].startsWith("did:iota:")}
                 <a
                     class="cut-text"
                     href={`${IOTA_IDENTITY_RESOLVER}/${entry[1]}`}

--- a/identity-enabler/holder-mobile-app/src/config.ts
+++ b/identity-enabler/holder-mobile-app/src/config.ts
@@ -17,3 +17,5 @@ export const TUTORIAL_BASE_URL = "https://jmcanterafonseca-iota.github.io/zebra-
 export const IDENTITY_WASM_PATH = "/wasm/identity_wasm_bg.wasm";
 
 export const BACK_BUTTON_EXIT_GRACE_PERIOD = 2000; // 2s is same duration as "short" Toast
+
+export const IOTA_IDENTITY_RESOLVER = "https://explorer.iota.org/mainnet/identity-resolver";

--- a/identity-enabler/holder-mobile-app/src/web/css/global.css
+++ b/identity-enabler/holder-mobile-app/src/web/css/global.css
@@ -135,3 +135,11 @@ i {
 .rotate-180 {
     transform: rotate(180deg);
 }
+
+/* 
+  Show a little arrow glyph after `target="_blank"` anchors.
+*/
+a[target="_blank"]:after {
+    content: " \2197";
+    font-size: 0.9em;
+}

--- a/identity-enabler/verifier-mobile-app/src/components/ObjectList.svelte
+++ b/identity-enabler/verifier-mobile-app/src/components/ObjectList.svelte
@@ -1,4 +1,5 @@
 <script>
+    import { IOTA_IDENTITY_RESOLVER } from "../config";
     import { flattenObj } from "../lib/helpers";
 
     export let object;
@@ -8,7 +9,16 @@
     {#each Object.entries(flattenObj(object)) as entry}
         <li>
             <p>{entry[0].split(".").pop()}</p>
-            <span class="cut-text">{entry[1]}</span>
+            {#if entry[1]?.startsWith("did:iota:")}
+                <a
+                    class="cut-text"
+                    href={`${IOTA_IDENTITY_RESOLVER}/${entry[1]}`}
+                    target="_blank"
+                    title="View in IOTA Explorer">{entry[1]}</a
+                >
+            {:else}
+                <span class="cut-text">{entry[1]}</span>
+            {/if}
         </li>
     {/each}
 </ul>
@@ -48,7 +58,8 @@
         margin: 0.43vh 0;
     }
 
-    li > span {
+    li > span,
+    li > a {
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
         font-size: 2vh;

--- a/identity-enabler/verifier-mobile-app/src/components/ObjectList.svelte
+++ b/identity-enabler/verifier-mobile-app/src/components/ObjectList.svelte
@@ -9,7 +9,7 @@
     {#each Object.entries(flattenObj(object)) as entry}
         <li>
             <p>{entry[0].split(".").pop()}</p>
-            {#if entry[1]?.startsWith("did:iota:")}
+            {#if typeof entry[1] === "string" && entry[1].startsWith("did:iota:")}
                 <a
                     class="cut-text"
                     href={`${IOTA_IDENTITY_RESOLVER}/${entry[1]}`}

--- a/identity-enabler/verifier-mobile-app/src/config.ts
+++ b/identity-enabler/verifier-mobile-app/src/config.ts
@@ -15,3 +15,5 @@ export const TUTORIAL_BASE_URL = "https://jmcanterafonseca-iota.github.io/zebra-
 export const IDENTITY_WASM_PATH = "/wasm/identity_wasm_bg.wasm";
 
 export const BACK_BUTTON_EXIT_GRACE_PERIOD = 2000; // 2s is same duration as "short" Toast
+
+export const IOTA_IDENTITY_RESOLVER = "https://explorer.iota.org/mainnet/identity-resolver";

--- a/identity-enabler/verifier-mobile-app/src/web/css/global.css
+++ b/identity-enabler/verifier-mobile-app/src/web/css/global.css
@@ -135,3 +135,11 @@ i {
 .rotate-180 {
     transform: rotate(180deg);
 }
+
+/* 
+  Show a little arrow glyph after `target="_blank"` anchors.
+*/
+a[target="_blank"]:after {
+    content: " \2197";
+    font-size: 0.9em;
+}


### PR DESCRIPTION
Closes https://github.com/ZebraDevs/Zebra-Iota-Edge-SDK/issues/42

- Renders entries starting with `did:iota:` in ObjectLists as anchor links
- Anchor links open the IOTA Identity resolver in a "new page". On Android this will open in the external browser app
- Added a style to display an arrow glyph for anchor tags with `target="_blank"`

![msedge_xUs8crKwX2](https://user-images.githubusercontent.com/20902401/146920425-11fbbc5c-9cc4-4e93-a305-054843b2d515.png)

