### PR TITLE
Add subject, issuer and issuanceDate to the header of credential pages and issuer to list items on home pages

### DIFF
--- a/identity-enabler/deviceId-mobile-app/rollup.config.js
+++ b/identity-enabler/deviceId-mobile-app/rollup.config.js
@@ -14,6 +14,27 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
+function serve() {
+    let server;
+
+    function toExit() {
+        if (server) server.kill(0);
+    }
+
+    return {
+        writeBundle() {
+            if (server) return;
+            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
+                stdio: ["ignore", "inherit", "inherit"],
+                shell: true
+            });
+
+            process.on("SIGTERM", toExit);
+            process.on("exit", toExit);
+        }
+    };
+}
+
 export default {
     input: "src/main.ts",
     output: {
@@ -73,6 +94,9 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
+        // In dev mode, call `npm run start` once
+        // the bundle has been generated
+        !production && serve(),
 
         // Watch the `public` directory and refresh the
         // browser on changes when not in production

--- a/identity-enabler/deviceId-mobile-app/rollup.config.js
+++ b/identity-enabler/deviceId-mobile-app/rollup.config.js
@@ -14,27 +14,6 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
-function serve() {
-    let server;
-
-    function toExit() {
-        if (server) server.kill(0);
-    }
-
-    return {
-        writeBundle() {
-            if (server) return;
-            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
-                stdio: ["ignore", "inherit", "inherit"],
-                shell: true
-            });
-
-            process.on("SIGTERM", toExit);
-            process.on("exit", toExit);
-        }
-    };
-}
-
 export default {
     input: "src/main.ts",
     output: {
@@ -94,9 +73,6 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
-        // In dev mode, call `npm run start` once
-        // the bundle has been generated
-        !production && serve(),
 
         // Watch the `public` directory and refresh the
         // browser on changes when not in production

--- a/identity-enabler/deviceId-mobile-app/src/App.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/App.svelte
@@ -64,7 +64,6 @@
         const storedIdentity = await identityService.retrieveIdentity();
 
         if (storedIdentity) {
-            console.log("Found identity", storedIdentity);
             displayHome = true;
         }
     });

--- a/identity-enabler/deviceId-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/components/CredentialHeader.svelte
@@ -12,16 +12,17 @@
     <h2>{credential.type[1]}</h2>
     {#if !hideDetails}
         <p>
-            <span>Issued to </span>
-            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" class="emphasis" target="_blank">
-                {shortenDID(credential.credentialSubject.id)}
-            </a>
-            <span> by </span>
-            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" class="emphasis" target="_blank"
-                >{credential.issuer.name}
+            <span>Issued by </span>
+            <a
+                href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id ?? credential.issuer}"
+                class="emphasis"
+                target="_blank"
+                >{credential.issuer.name ?? shortenDID(credential.issuer.id ?? credential.issuer)}
             </a>
             <span> at </span>
-            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span>
+            <span class="emphasis"
+                >{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span
+            >
         </p>
     {/if}
 </div>

--- a/identity-enabler/deviceId-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/components/CredentialHeader.svelte
@@ -21,7 +21,7 @@
                 >{credential.issuer.name}
             </a>
             <span> at </span>
-            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString()}</span>
+            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span>
         </p>
     {/if}
 </div>

--- a/identity-enabler/deviceId-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/components/CredentialHeader.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import { IOTA_IDENTITY_RESOLVER } from "../config";
+    import { shortenDID } from "../lib/ui/helpers";
+
+    export let credential;
+    export let color = "black";
+    export let hideDetails = false;
+</script>
+
+<div id="wrapper" style="color: {color};">
+    <i class="icon-credential" />
+    <h2>{credential.type[1]}</h2>
+    {#if !hideDetails}
+        <p>
+            <span>Issued to </span>
+            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" class="emphasis" target="_blank">
+                {shortenDID(credential.credentialSubject.id)}
+            </a>
+            <span> by </span>
+            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" class="emphasis" target="_blank"
+                >{credential.issuer.name}
+            </a>
+            <span> at </span>
+            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString()}</span>
+        </p>
+    {/if}
+</div>
+
+<style>
+    #wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 0 2rem;
+        font-family: "Proxima Nova", sans-serif;
+    }
+
+    .icon-credential {
+        color: inherit;
+        font-size: 64px;
+    }
+
+    h2 {
+        margin: 0;
+        font-size: 1.4em;
+    }
+
+    p {
+        line-height: 1.5em;
+    }
+
+    p .emphasis {
+        font-weight: bold;
+        padding: 0 0.2rem;
+    }
+
+    a {
+        color: inherit;
+    }
+
+    a:visited {
+        color: unset;
+    }
+</style>

--- a/identity-enabler/deviceId-mobile-app/src/components/ListItem.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/components/ListItem.svelte
@@ -1,7 +1,7 @@
 <script type="ts">
     export let onClick;
-    export let heading: string | undefined = undefined;
-    export let subheading: string;
+    export let heading: string;
+    export let subheading: string | undefined = undefined;
     export let icon: string = "credential";
     export let iconColor: string = "black";
     export let arrow = true;
@@ -10,14 +10,14 @@
 <li on:click={onClick}>
     <i class="icon-{icon}" style="color: {iconColor};" />
     <div class="text-container">
-        {#if heading}
+        <div class="overflow-container">
+            <h5>{heading}</h5>
+        </div>
+        {#if subheading}
             <div class="overflow-container">
-                <h5>{heading}</h5>
+                <h6>{subheading}</h6>
             </div>
         {/if}
-        <div class="overflow-container">
-            <h6>{subheading}</h6>
-        </div>
     </div>
     {#if arrow}
         <i class="icon-chevron rotate-180" />
@@ -59,19 +59,16 @@
         display: inline;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
-        font-size: 0.75em;
-        letter-spacing: 0.06em;
-        color: #8593ac;
-        text-transform: uppercase;
-        margin: 0 0 0.9vh 0;
+        font-size: 1em;
+        margin: 0;
     }
 
     h6 {
         display: inline;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
-        font-size: 1em;
+        font-size: 0.75em;
         margin: 0;
-        color: #051923;
+        color: #8593ac;
     }
 </style>

--- a/identity-enabler/deviceId-mobile-app/src/components/modal/Share.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/components/modal/Share.svelte
@@ -7,17 +7,17 @@
     const { close } = getContext("simple-modal");
     const { Share } = Plugins;
 
-    const credential = window.history.state.credential;
+    const vp = window.history.state.vp;
 
     function share() {
-        navigate("/createPresentation", { state: { credential } });
+        navigate("/createPresentation", { state: { vp } });
         close();
     }
 
     async function shareJSON() {
         await Share.share({
             title: "Verifiable Presentation",
-            text: JSON.stringify(credential, null, 2)
+            text: JSON.stringify(vp, null, 2)
         });
         close();
     }

--- a/identity-enabler/deviceId-mobile-app/src/config.ts
+++ b/identity-enabler/deviceId-mobile-app/src/config.ts
@@ -6,10 +6,6 @@ export const IOTA_NODE_URL = "https://chrysalis-nodes.iota.org";
 
 export const IOTA_PERMANODE_URL = "https://chrysalis-chronicle.iota.org/api/mainnet/";
 
-export const DEFAULT_LANGUAGE = "English";
-
-export const DEFAULT_LOCALE = "en";
-
 export const TUTORIAL_BASE_URL = "https://zebradevs.github.io/Zebra-Iota-Edge-SDK/docs";
 
 export const IDENTITY_WASM_PATH = "/wasm/identity_wasm_bg.wasm";

--- a/identity-enabler/deviceId-mobile-app/src/lib/scan.ts
+++ b/identity-enabler/deviceId-mobile-app/src/lib/scan.ts
@@ -69,7 +69,7 @@ export async function handleScannerData(decodedText: string, method: "Camera" | 
         text: "Credential verified!",
         position: "center"
     });
-    navigate("credential", { state: { credential: vp, save: true } });
+    navigate("credential", { state: { vp, save: true } });
 }
 
 async function handleError(message: string, scanSoundStart?: number) {

--- a/identity-enabler/deviceId-mobile-app/src/lib/store.ts
+++ b/identity-enabler/deviceId-mobile-app/src/lib/store.ts
@@ -1,9 +1,6 @@
 import { writable } from "svelte/store";
 import { persistent } from "./helpers";
-import init from "./init";
 import type { VerifiableCredentialEnrichment } from "../models/types/identity";
-
-init();
 
 const hasSetupAccountInitialState = false;
 /**

--- a/identity-enabler/deviceId-mobile-app/src/lib/store.ts
+++ b/identity-enabler/deviceId-mobile-app/src/lib/store.ts
@@ -1,6 +1,5 @@
 import { writable } from "svelte/store";
 import { persistent } from "./helpers";
-import type { VerifiableCredentialEnrichment } from "../models/types/identity";
 
 const hasSetupAccountInitialState = false;
 /**
@@ -25,16 +24,6 @@ export type ModalStatus = {
 
 const modalStatusInitialState = { active: false, type: null, props: null };
 export const modalStatus = writable<ModalStatus>(modalStatusInitialState);
-
-export interface InternalCredentialDataModel {
-    id: string;
-    metaInformation: {
-        issuer: string;
-        receivedAt: string;
-    };
-    enrichment: VerifiableCredentialEnrichment | null;
-    credentialDocument: any;
-}
 
 export const loadingScreen = writable<string | void>();
 

--- a/identity-enabler/deviceId-mobile-app/src/lib/ui/helpers.ts
+++ b/identity-enabler/deviceId-mobile-app/src/lib/ui/helpers.ts
@@ -15,3 +15,13 @@ export async function playAudio(sound: string) {
 
     await audio.play();
 }
+
+/**
+ * Shorten a DID for display.
+ *
+ * @param did DID
+ * @returns Short DID with ellipsis.
+ */
+export function shortenDID(did: string): string {
+    return `${did.substring(0, 15)}...${did.substring(did.length - 6)}`;
+}

--- a/identity-enabler/deviceId-mobile-app/src/main.ts
+++ b/identity-enabler/deviceId-mobile-app/src/main.ts
@@ -1,4 +1,7 @@
 import App from "./App.svelte";
+import init from "./lib/init";
+
+init();
 
 const app = new App({
     target: document.body,

--- a/identity-enabler/deviceId-mobile-app/src/models/types/identity.ts
+++ b/identity-enabler/deviceId-mobile-app/src/models/types/identity.ts
@@ -15,10 +15,3 @@ export type IdentityConfig = {
     network: string;
     permanode?: string;
 };
-
-export type VerifiableCredentialEnrichment = {
-    issuerLabel: string;
-    logo: string;
-    credentialLabel: string;
-    theme: string;
-};

--- a/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
@@ -7,7 +7,7 @@
     import { loadingScreen } from "../lib/store";
     import { Plugins } from "@capacitor/core";
     import { showAlert } from "../lib/ui/helpers";
-    import { IOTA_IDENTITY_RESOLVER } from "../config";
+    import CredentialHeader from "../components/CredentialHeader.svelte";
 
     const { App } = Plugins;
     let showJSON = false;
@@ -15,13 +15,13 @@
     let singleTapped = false;
     const MAX_DOUBLE_TAP_DELAY = 500;
 
-    const credential = window.history.state.credential.verifiableCredential;
+    const vp = window.history.state.vp;
 
     function createMatrix() {
         // The return value is the canvas element
         bwipjs.toCanvas("presentation", {
             bcid: "datamatrix",
-            text: JSON.stringify(credential),
+            text: JSON.stringify(vp),
             scale: 3,
             padding: 20,
             backgroundcolor: "ffffff"
@@ -75,17 +75,13 @@
         await wait(MAX_DOUBLE_TAP_DELAY);
         singleTapped = false;
     }
-
-    function shortenDID(did: string): string {
-        return `${did.substring(0, 15)}...${did.substring(did.length - 6)}`;
-    }
 </script>
 
 <main>
     {#if showTutorial}
         <DevInfo page="Presentation" bind:showTutorial />
     {:else if showJSON}
-        <PresentationJson code={JSON.stringify(credential, null, 2)} bind:showJSON />
+        <PresentationJson code={JSON.stringify(vp, null, 2)} bind:showJSON />
     {/if}
 
     <header>
@@ -93,24 +89,7 @@
             <i on:click={goBack} class="icon-chevron" />
             <i on:click={onClickDev} class="icon-code" />
         </div>
-        <i class="icon-credential credential-logo" />
-        <p>{credential.type[1]}</p>
-        <div class="details">
-            <p>
-                <span
-                    >Subject: <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" target="_blank"
-                        >{shortenDID(credential.credentialSubject.id)}</a
-                    ></span
-                >
-            </p>
-            <p>
-                <span
-                    >Issuer: <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" target="_blank"
-                        >{credential.issuer.name}</a
-                    ></span
-                >
-            </p>
-        </div>
+        <CredentialHeader credential={vp.verifiableCredential} hideDetails={true} color="white" />
     </header>
 
     <div class="presentation-wrapper">
@@ -118,7 +97,7 @@
     </div>
 
     <footer class="footerContainer">
-        <p>Valid until {addDaysToDate(credential.issuanceDate, 30)}</p>
+        <p>Valid until {addDaysToDate(vp.verifiableCredential.issuanceDate, 30)}</p>
     </footer>
 </main>
 
@@ -139,44 +118,11 @@
     }
 
     header {
-        margin-bottom: 0;
+        margin-bottom: 1.5rem;
         display: flex;
         flex-direction: column;
         align-items: stretch;
         text-align: center;
-    }
-
-    header > p {
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 700;
-        font-size: 1.25em;
-        color: #fff;
-        margin: 0;
-        padding: 0 2rem;
-    }
-
-    .details {
-        padding: 1rem 2rem;
-    }
-
-    .details > p {
-        font-family: "Proxima Nova", sans-serif;
-        color: #fff;
-        margin: 0.3rem 0;
-    }
-
-    .details a {
-        color: white;
-        font-weight: bold;
-    }
-
-    .details a:visited {
-        color: unset;
-    }
-
-    .credential-logo {
-        font-size: 64px;
-        color: white;
     }
 
     .presentation-wrapper {

--- a/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
@@ -1,47 +1,62 @@
-<script>
+<script lang="ts">
     import { onMount } from "svelte";
     import bwipjs from "bwip-js";
     import { wait } from "../lib/helpers";
     import DevInfo from "./DevInfo.svelte";
     import PresentationJson from "./PresentationJSON.svelte";
     import { loadingScreen } from "../lib/store";
+    import { Plugins } from "@capacitor/core";
+    import { showAlert } from "../lib/ui/helpers";
+    import { IOTA_IDENTITY_RESOLVER } from "../config";
 
+    const { App } = Plugins;
     let showJSON = false;
     let showTutorial = false;
     let singleTapped = false;
     const MAX_DOUBLE_TAP_DELAY = 500;
 
-    const credential = window.history.state.credential;
+    const credential = window.history.state.credential.verifiableCredential;
 
     function createMatrix() {
-        loadingScreen.set("Generating DataMatrix...");
-        try {
-            // The return value is the canvas element
-            bwipjs.toCanvas("presentation", {
-                bcid: "datamatrix",
-                text: JSON.stringify(credential),
-                scale: 3,
-                padding: 20,
-                backgroundcolor: "ffffff"
-            });
-        } catch (e) {
-            console.error(e);
-        }
-        loadingScreen.set();
+        // The return value is the canvas element
+        bwipjs.toCanvas("presentation", {
+            bcid: "datamatrix",
+            text: JSON.stringify(credential),
+            scale: 3,
+            padding: 20,
+            backgroundcolor: "ffffff"
+        });
     }
 
-    const addDaysToDate = (date, days) => {
-        let dateOptions = { year: "numeric", month: "long", day: "numeric" };
+    const addDaysToDate = (date: string, days: number) => {
         let res = new Date(date);
         res.setDate(res.getDate() + days);
-        return res.toLocaleDateString("en-US", dateOptions);
+        return res.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
     };
 
-    onMount(() => {
-        createMatrix();
+    onMount(() => App.addListener("backButton", goBack).remove);
+    onMount(async () => {
+        loadingScreen.set("Generating DataMatrix...");
+        try {
+            createMatrix();
+        } catch (e) {
+            console.error(e);
+            await showAlert("Error", "Error creating DataMatrix. Please try again.");
+        }
+        loadingScreen.set();
     });
 
     function goBack() {
+        if (showTutorial) {
+            showTutorial = false;
+            return;
+        }
+
+        if (showJSON) {
+            showJSON = false;
+            return;
+        }
+
         window.history.back();
     }
 
@@ -60,6 +75,10 @@
         await wait(MAX_DOUBLE_TAP_DELAY);
         singleTapped = false;
     }
+
+    function shortenDID(did: string): string {
+        return `${did.substring(0, 15)}...${did.substring(did.length - 6)}`;
+    }
 </script>
 
 <main>
@@ -69,25 +88,38 @@
         <PresentationJson code={JSON.stringify(credential, null, 2)} bind:showJSON />
     {/if}
 
-    <div class="wrapper">
+    <header>
         <div class="options-wrapper">
             <i on:click={goBack} class="icon-chevron" />
             <i on:click={onClickDev} class="icon-code" />
         </div>
-        <div class="header">
-            <i class="icon-credential credential-logo" />
-            <header>
-                <span>Device {credential?.verifiableCredential?.credentialSubject?.deviceName}</span>
-                <p>{credential?.metaInformation?.issuer ?? "No issuer information"}</p>
-            </header>
+        <i class="icon-credential credential-logo" />
+        <p>{credential.type[1]}</p>
+        <div class="details">
+            <p>
+                <span
+                    >Subject: <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" target="_blank"
+                        >{shortenDID(credential.credentialSubject.id)}</a
+                    ></span
+                >
+            </p>
+            <p>
+                <span
+                    >Issuer: <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" target="_blank"
+                        >{credential.issuer.name}</a
+                    ></span
+                >
+            </p>
         </div>
-        <div class="presentation-wrapper">
-            <canvas id="presentation" on:click={onClickDataMatrix} />
-        </div>
-        <footer class="footerContainer">
-            <p>Valid until {addDaysToDate(credential?.verifiableCredential?.issuanceDate, 30)}</p>
-        </footer>
+    </header>
+
+    <div class="presentation-wrapper">
+        <canvas id="presentation" on:click={onClickDataMatrix} />
     </div>
+
+    <footer class="footerContainer">
+        <p>Valid until {addDaysToDate(credential.issuanceDate, 30)}</p>
+    </footer>
 </main>
 
 <style>
@@ -104,65 +136,68 @@
     canvas {
         position: relative;
         width: 100%;
-        z-index: 5;
     }
 
-    header > p {
-        margin: 2vh 0;
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 700;
-        font-size: 5vw;
-        line-height: 5vw;
-        color: #fff;
-        padding: 0;
-    }
-
-    header > span {
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 600;
-        font-size: 1.7vh;
-        line-height: 2.3vh;
-        color: #fff;
-    }
-
-    .wrapper {
+    header {
+        margin-bottom: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
         text-align: center;
     }
 
-    .options-wrapper > i {
+    header > p {
+        font-family: "Proxima Nova", sans-serif;
+        font-weight: 700;
+        font-size: 1.25em;
+        color: #fff;
+        margin: 0;
+        padding: 0 2rem;
+    }
+
+    .details {
+        padding: 1rem 2rem;
+    }
+
+    .details > p {
+        font-family: "Proxima Nova", sans-serif;
+        color: #fff;
+        margin: 0.3rem 0;
+    }
+
+    .details a {
         color: white;
+        font-weight: bold;
+    }
+
+    .details a:visited {
+        color: unset;
     }
 
     .credential-logo {
-        color: white;
         font-size: 64px;
+        color: white;
     }
 
     .presentation-wrapper {
-        height: fit-content;
-        position: relative;
         background: white;
         display: flex;
         flex-direction: row;
         align-items: center;
         justify-content: center;
-        width: 100%;
     }
 
-    @media (min-width: 640px) {
-        main {
-            max-width: none;
-        }
+    footer {
+        padding: 1.5rem;
+        text-align: center;
     }
 
     footer > p {
         color: #fff;
-        padding: 2vh 0 1vh 0;
         margin: 0;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 500;
-        font-size: 2.9vh;
-        line-height: 3.5vh;
+        font-size: 1.2em;
     }
 
     .options-wrapper {
@@ -171,12 +206,9 @@
         justify-content: space-between;
         margin: 3.5vh 3.5vh 0 3.5vh;
         position: relative;
-        z-index: 2;
     }
 
-    .footerContainer {
-        position: fixed;
-        text-align: center;
-        width: 100%;
+    .options-wrapper > i {
+        color: white;
     }
 </style>

--- a/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
@@ -31,7 +31,11 @@
     const addDaysToDate = (date: string, days: number) => {
         let res = new Date(date);
         res.setDate(res.getDate() + days);
-        return res.toLocaleDateString([...window.navigator.languages], { year: "numeric", month: "long", day: "numeric" });
+        return res.toLocaleDateString([...window.navigator.languages], {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        });
     };
 
     onMount(() => App.addListener("backButton", goBack).remove);

--- a/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/CreatePresentation.svelte
@@ -31,7 +31,7 @@
     const addDaysToDate = (date: string, days: number) => {
         let res = new Date(date);
         res.setDate(res.getDate() + days);
-        return res.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+        return res.toLocaleDateString([...window.navigator.languages], { year: "numeric", month: "long", day: "numeric" });
     };
 
     onMount(() => App.addListener("backButton", goBack).remove);

--- a/identity-enabler/deviceId-mobile-app/src/pages/Credential.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/Credential.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
     import { Plugins } from "@capacitor/core";
     import { onMount } from "svelte";
     import { navigate } from "svelte-routing";
@@ -7,11 +7,12 @@
     import Button from "../components/Button.svelte";
     import ObjectList from "../components/ObjectList.svelte";
     import DevInfo from "./DevInfo.svelte";
+    import CredentialHeader from "../components/CredentialHeader.svelte";
 
     const { App } = Plugins;
     let showTutorial = false;
 
-    const credential = window.history.state.credential;
+    const vp = window.history.state.vp;
     const save = window?.history?.state?.save;
 
     onMount(() => App.addListener("backButton", goBack).remove);
@@ -20,13 +21,13 @@
         modalStatus.set({
             active: true,
             type: "share",
-            props: { credential }
+            props: { vp }
         });
     }
 
     async function onSaveCredential() {
         credentials.update(creds => {
-            creds[credential.verifiableCredential.type[1].split(/\b/)[0].toLowerCase()] = credential;
+            creds[vp.verifiableCredential.type[1].split(/\b/)[0].toLowerCase()] = vp;
             return creds;
         });
         navigate("/home");
@@ -34,7 +35,7 @@
 
     function goBack() {
         if ($modalStatus.active) {
-            modalStatus.set({ active: false });
+            modalStatus.set({ active: false, type: null });
             return;
         }
 
@@ -63,13 +64,11 @@
                 <i on:click={onClickDev} class="icon-code" />
             </div>
             <header>
-                <i class="icon-zebra credential-logo" />
-                <p>IOTA</p>
-                <p>{credential.verifiableCredential.type[1]}</p>
+                <CredentialHeader credential={vp.verifiableCredential} />
             </header>
         </div>
         <section>
-            <ObjectList object={credential.verifiableCredential.credentialSubject} />
+            <ObjectList object={vp.verifiableCredential.credentialSubject} />
         </section>
         <footer>
             {#if save}
@@ -99,7 +98,7 @@
 
     .header-wrapper {
         text-align: center;
-        padding-bottom: 3vh;
+        padding-bottom: 0.5rem;
         background-color: #aee693;
     }
 
@@ -109,24 +108,6 @@
         z-index: 1;
         height: fit-content;
         margin-bottom: 0;
-    }
-
-    header > p {
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 700;
-        font-size: 2.6vh;
-        line-height: 2.6vh;
-        margin: 0;
-    }
-
-    header > p:nth-child(3) {
-        text-transform: uppercase;
-        margin: 1.7vh 0 0 0;
-    }
-
-    header > p:nth-child(2) {
-        margin: 1.2vh 0 1.7vh 0;
-        font-size: 1.7vh;
     }
 
     section {
@@ -139,10 +120,6 @@
         width: 100%;
         bottom: 0;
         z-index: 1;
-    }
-
-    .credential-logo {
-        font-size: 64px;
     }
 
     .options-wrapper {

--- a/identity-enabler/deviceId-mobile-app/src/pages/Home.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/Home.svelte
@@ -92,13 +92,13 @@
             <p>Device {$account.name}</p>
         </name-wrapper>
         <section>
-            {#each localCredentials as credential}
+            {#each localCredentials as vp}
                 <div class="list">
                     <ListItem
                         icon="chip"
-                        onClick={() => navigate("credential", { state: { credential } })}
-                        heading={"IOTA"}
-                        subheading={credential.verifiableCredential.type[1]}
+                        onClick={() => navigate("/credential", { state: { vp } })}
+                        heading={vp.verifiableCredential.type[1]}
+                        subheading="Issued by {vp.verifiableCredential.issuer.name}"
                     />
                 </div>
             {/each}
@@ -109,7 +109,7 @@
                         iconColor="#78d64b"
                         onClick={createQR}
                         arrow={false}
-                        subheading="Request Device ID credential"
+                        heading="Request Device ID credential"
                     />
                 </div>
             {/if}

--- a/identity-enabler/deviceId-mobile-app/src/pages/Home.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/Home.svelte
@@ -9,6 +9,7 @@
     import type { IdentityService } from "../services/identityService";
     import { wait } from "../lib/helpers";
     import { BACK_BUTTON_EXIT_GRACE_PERIOD } from "../config";
+    import { shortenDID } from "../lib/ui/helpers";
 
     let showTutorial = false;
 
@@ -98,7 +99,8 @@
                         icon="chip"
                         onClick={() => navigate("/credential", { state: { vp } })}
                         heading={vp.verifiableCredential.type[1]}
-                        subheading="Issued by {vp.verifiableCredential.issuer.name}"
+                        subheading="Issued by {vp.verifiableCredential.issuer.name ??
+                            shortenDID(vp.verifiableCredential.issuer.id ?? vp.verifiableCredential.issuer)}"
                     />
                 </div>
             {/each}

--- a/identity-enabler/deviceId-mobile-app/src/pages/PresentationJSON.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/PresentationJSON.svelte
@@ -1,7 +1,7 @@
 <script>
     import Markdown from "../components/Markdown.svelte";
 
-    export let showJSON = Boolean;
+    export let showJSON = true;
     export let code = "";
 
     function onClose() {

--- a/identity-enabler/deviceId-mobile-app/src/schemas/index.ts
+++ b/identity-enabler/deviceId-mobile-app/src/schemas/index.ts
@@ -1,7 +1,0 @@
-export const DIDMapping: { [DID: string]: { logo: string; issuerLabel: string; theme: string } } = {
-    "did:IOTA:CQMOHTVOCNYQHTSUBSDPNLRBYTBBAHRTOQZZCN9DUWXCVGAYOYGFBEQJOCFXPSCKPPNAZPKALAVYMZICF": {
-        issuerLabel: "Government",
-        logo: "government",
-        theme: "#00ffaa"
-    }
-};

--- a/identity-enabler/deviceId-mobile-app/src/services/identityService.ts
+++ b/identity-enabler/deviceId-mobile-app/src/services/identityService.ts
@@ -1,8 +1,6 @@
 import Keychain from "../lib/keychain";
-import { DIDMapping } from "../schemas";
 import { parse } from "../lib/helpers";
-import type { InternalCredentialDataModel } from "../lib/store";
-import type { Identity, IdentityConfig, VerifiableCredentialEnrichment } from "../models/types/identity";
+import type { Identity, IdentityConfig } from "../models/types/identity";
 import * as IotaIdentity from "@iota/identity-wasm/web";
 import { IDENTITY_WASM_PATH } from "../config";
 
@@ -130,57 +128,6 @@ export class IdentityService {
         }
     }
 
-    retrieveCredentials(ids: string[]): Promise<InternalCredentialDataModel[]> {
-        return Promise.all(ids.map(id => Keychain.get(id)))
-            .then(data => data.map(entry => parse(entry.value)))
-            .catch(e => {
-                console.error(e);
-                return [];
-            });
-    }
-
-    /**
-     * Stores credential in keychain
-     *
-     * @method storeCredential
-     *
-     * @param {string} credentialId
-     * @param {VerifiableCredentialDataModel} credential
-     *
-     * @returns {Promise}
-     */
-    storeCredential(credentialId: string, credential: InternalCredentialDataModel): Promise<{ value: boolean }> {
-        return Keychain.set(credentialId, JSON.stringify(credential));
-    }
-
-    /**
-     * Remove credential from keychain
-     *
-     * @method removeCredential
-     *
-     * @param {string} credentialId
-     *
-     * @returns {Promise}
-     */
-    removeCredential(credentialId: string): Promise<{ value: boolean }> {
-        return Keychain.remove(credentialId);
-    }
-
-    /**
-     * Retrieves credential from keychain
-     *
-     * @method retrieveCredential
-     *
-     * @param {string} credentialId
-     *
-     * @returns {Promise}
-     */
-    retrieveCredential(credentialId: string): Promise<IotaIdentity.VerifiableCredential> {
-        return Keychain.get(credentialId)
-            .then(async data => parse(data.value))
-            .catch(() => null);
-    }
-
     /**
      * Creates verifiable presentations for provided schema names
      *
@@ -229,17 +176,6 @@ export class IdentityService {
             console.error("Error during VP Check: " + err);
             return false;
         }
-    }
-
-    enrichCredential(credential: any): VerifiableCredentialEnrichment {
-        const override = DIDMapping[credential.issuer];
-        const enrichment = {
-            issuerLabel: override?.issuerLabel ?? "iota", // credential.issuer
-            logo: override?.logo ?? "personal",
-            credentialLabel: credential?.type?.[1],
-            theme: override?.theme ?? "#550000"
-        };
-        return enrichment;
     }
 
     prepareCredentialForDisplay(credential: any): any {

--- a/identity-enabler/holder-mobile-app/rollup.config.js
+++ b/identity-enabler/holder-mobile-app/rollup.config.js
@@ -14,6 +14,27 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
+function serve() {
+    let server;
+
+    function toExit() {
+        if (server) server.kill(0);
+    }
+
+    return {
+        writeBundle() {
+            if (server) return;
+            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
+                stdio: ["ignore", "inherit", "inherit"],
+                shell: true
+            });
+
+            process.on("SIGTERM", toExit);
+            process.on("exit", toExit);
+        }
+    };
+}
+
 export default {
     input: "src/main.ts",
     output: {
@@ -73,6 +94,10 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
+        // In dev mode, call `npm run start` once
+        // the bundle has been generated
+        !production && serve(),
+
         // Watch the `public` directory and refresh the
         // browser on changes when not in production
         !production && livereload("public"),

--- a/identity-enabler/holder-mobile-app/rollup.config.js
+++ b/identity-enabler/holder-mobile-app/rollup.config.js
@@ -14,27 +14,6 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
-function serve() {
-    let server;
-
-    function toExit() {
-        if (server) server.kill(0);
-    }
-
-    return {
-        writeBundle() {
-            if (server) return;
-            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
-                stdio: ["ignore", "inherit", "inherit"],
-                shell: true
-            });
-
-            process.on("SIGTERM", toExit);
-            process.on("exit", toExit);
-        }
-    };
-}
-
 export default {
     input: "src/main.ts",
     output: {
@@ -94,10 +73,6 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
-        // In dev mode, call `npm run start` once
-        // the bundle has been generated
-        !production && serve(),
-
         // Watch the `public` directory and refresh the
         // browser on changes when not in production
         !production && livereload("public"),

--- a/identity-enabler/holder-mobile-app/src/App.svelte
+++ b/identity-enabler/holder-mobile-app/src/App.svelte
@@ -58,7 +58,6 @@
         const storedIdentity = await identityService.retrieveIdentity();
 
         if (storedIdentity) {
-            console.log("Found identity", storedIdentity);
             displayHome = true;
         }
     });

--- a/identity-enabler/holder-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/CredentialHeader.svelte
@@ -12,16 +12,17 @@
     <h2>{credential.type[1]}</h2>
     {#if !hideDetails}
         <p>
-            <span>Issued to </span>
-            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" class="emphasis" target="_blank">
-                {shortenDID(credential.credentialSubject.id)}
-            </a>
-            <span> by </span>
-            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" class="emphasis" target="_blank"
-                >{credential.issuer.name}
+            <span>Issued by </span>
+            <a
+                href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id ?? credential.issuer}"
+                class="emphasis"
+                target="_blank"
+                >{credential.issuer.name ?? shortenDID(credential.issuer.id ?? credential.issuer)}
             </a>
             <span> at </span>
-            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span>
+            <span class="emphasis"
+                >{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span
+            >
         </p>
     {/if}
 </div>

--- a/identity-enabler/holder-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/CredentialHeader.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+    import { IOTA_IDENTITY_RESOLVER } from "../config";
+    import { shortenDID } from "../lib/ui/helpers";
+
+    export let credential;
+    export let color = "white";
+    export let hideDetails = false;
+</script>
+
+<div id="wrapper" style="color: {color};">
+    <i class="icon-credential" />
+    <h2>{credential.type[1]}</h2>
+    {#if !hideDetails}
+        <p>
+            <span>Issued to </span>
+            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" class="emphasis" target="_blank">
+                {shortenDID(credential.credentialSubject.id)}
+            </a>
+            <span> by </span>
+            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" class="emphasis" target="_blank"
+                >{credential.issuer.name}
+            </a>
+            <span> at </span>
+            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString()}</span>
+        </p>
+    {/if}
+</div>
+
+<style>
+    #wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 0 2rem;
+        font-family: "Proxima Nova", sans-serif;
+    }
+
+    .icon-credential {
+        color: inherit;
+        font-size: 64px;
+    }
+
+    h2 {
+        margin: 0;
+        font-size: 1.4em;
+    }
+
+    p {
+        line-height: 1.5em;
+    }
+
+    p .emphasis {
+        font-weight: bold;
+        padding: 0 0.2rem;
+    }
+
+    a {
+        color: inherit;
+    }
+
+    a:visited {
+        color: unset;
+    }
+</style>

--- a/identity-enabler/holder-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/CredentialHeader.svelte
@@ -21,7 +21,7 @@
                 >{credential.issuer.name}
             </a>
             <span> at </span>
-            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString()}</span>
+            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span>
         </p>
     {/if}
 </div>

--- a/identity-enabler/holder-mobile-app/src/components/ListItem.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/ListItem.svelte
@@ -1,7 +1,7 @@
 <script type="ts">
     export let onClick;
-    export let heading: string | undefined = undefined;
-    export let subheading: string;
+    export let heading: string;
+    export let subheading: string | undefined = undefined;
     export let icon: string = "credential";
     export let iconColor: string = "black";
     export let arrow = true;
@@ -10,14 +10,14 @@
 <li on:click={onClick}>
     <i class="icon-{icon}" style="color: {iconColor};" />
     <div class="text-container">
-        {#if heading}
+        <div class="overflow-container">
+            <h5>{heading}</h5>
+        </div>
+        {#if subheading}
             <div class="overflow-container">
-                <h5>{heading}</h5>
+                <h6>{subheading}</h6>
             </div>
         {/if}
-        <div class="overflow-container">
-            <h6>{subheading}</h6>
-        </div>
     </div>
     {#if arrow}
         <i class="icon-chevron rotate-180" />
@@ -59,19 +59,16 @@
         display: inline;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
-        font-size: 0.75em;
-        letter-spacing: 0.06em;
-        color: #8593ac;
-        text-transform: uppercase;
-        margin: 0 0 0.9vh 0;
+        font-size: 1em;
+        margin: 0;
     }
 
     h6 {
         display: inline;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
-        font-size: 1em;
+        font-size: 0.75em;
         margin: 0;
-        color: #051923;
+        color: #8593ac;
     }
 </style>

--- a/identity-enabler/holder-mobile-app/src/components/modal/Share.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/modal/Share.svelte
@@ -4,6 +4,7 @@
     import { Plugins } from "@capacitor/core";
     import Button from "../Button.svelte";
     import { ServiceFactory } from "../../factories/serviceFactory";
+    import { showAlert } from "../../lib/ui/helpers";
 
     const { close } = getContext("simple-modal");
     const { Share } = Plugins;
@@ -30,8 +31,8 @@
                 text: presentationJSON
             });
         } catch (error) {
-            console.error("Error sharing: " + error);
-            return;
+            console.error(error);
+            await showAlert("Error", error.message);
         }
     }
 </script>

--- a/identity-enabler/holder-mobile-app/src/components/modal/Share.svelte
+++ b/identity-enabler/holder-mobile-app/src/components/modal/Share.svelte
@@ -21,7 +21,7 @@
             const storedIdentity = await identityService.retrieveIdentity();
             const verifiablePresentation = await identityService.createVerifiablePresentation(
                 storedIdentity,
-                credential?.credentialDocument
+                credential
             );
             const presentationJSON = JSON.stringify(verifiablePresentation, null, 2);
 
@@ -30,7 +30,7 @@
                 text: presentationJSON
             });
         } catch (error) {
-            console.log("Error sharing: " + error);
+            console.error("Error sharing: " + error);
             return;
         }
     }

--- a/identity-enabler/holder-mobile-app/src/config.ts
+++ b/identity-enabler/holder-mobile-app/src/config.ts
@@ -6,10 +6,6 @@ export const IOTA_NODE_URL = "https://chrysalis-nodes.iota.org";
 
 export const IOTA_PERMANODE_URL = "https://chrysalis-chronicle.iota.org/api/mainnet/";
 
-export const DEFAULT_LANGUAGE = "English";
-
-export const DEFAULT_LOCALE = "en";
-
 export const RANDOM_USER_DATA_API_URL = "https://randomuser.me/api/?nat=us,au,ca,ie,gb";
 
 export const TUTORIAL_BASE_URL = "https://zebradevs.github.io/Zebra-Iota-Edge-SDK/docs";

--- a/identity-enabler/holder-mobile-app/src/lib/helpers.ts
+++ b/identity-enabler/holder-mobile-app/src/lib/helpers.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from "uuid";
 import { writable, Writable } from "svelte/store";
 import { RANDOM_USER_DATA_API_URL } from "../config";
 
@@ -185,10 +184,6 @@ export function persistent<T>(key: string, initialValue: T, saveTransformation?:
     });
 
     return state;
-}
-
-export function generateRandomId(): string {
-    return uuidv4();
 }
 
 export function flattenObj(ob) {

--- a/identity-enabler/holder-mobile-app/src/lib/store.ts
+++ b/identity-enabler/holder-mobile-app/src/lib/store.ts
@@ -1,11 +1,9 @@
 import { writable } from "svelte/store";
 import { persistent } from "./helpers";
-import init from "./init";
 import { ServiceFactory } from "../factories/serviceFactory";
 import type { VerifiableCredentialEnrichment } from "../models/types/identity";
 import type { IdentityService } from "../services/identityService";
 
-init();
 const identityService = ServiceFactory.get<IdentityService>("identity");
 
 export const updateStorage = async (key, value) => {

--- a/identity-enabler/holder-mobile-app/src/lib/store.ts
+++ b/identity-enabler/holder-mobile-app/src/lib/store.ts
@@ -1,10 +1,5 @@
 import { writable } from "svelte/store";
 import { persistent } from "./helpers";
-import { ServiceFactory } from "../factories/serviceFactory";
-import type { VerifiableCredentialEnrichment } from "../models/types/identity";
-import type { IdentityService } from "../services/identityService";
-
-const identityService = ServiceFactory.get<IdentityService>("identity");
 
 export const updateStorage = async (key, value) => {
     try {
@@ -41,23 +36,12 @@ const hasSetupAccountInitialState = false;
  */
 export const hasSetupAccount = persistent<boolean>("hasSetupAccount", hasSetupAccountInitialState);
 
-const listOfCredentialsInitialState = {
-    init: false,
-    values: []
-};
-export const listOfCredentials = persistent<{ init: boolean; values: string[] }>(
-    "listOfCredentials",
-    listOfCredentialsInitialState,
-    value => ({ ...value, init: false })
-);
-
 const credentialsInitialState = {
     personal: "",
     health: "",
-    blood: "",
-    organization: ""
+    blood: ""
 };
-export const credentials = persistent<{ personal: string; health: string; blood: string; organization: string }>(
+export const credentials = persistent<{ personal: string; health: string; blood: string }>(
     "credentials",
     credentialsInitialState
 );
@@ -80,50 +64,13 @@ export const modalStatus = writable<ModalStatus>(modalStatusInitialState);
 const landingIndexInitialState = 0;
 export const landingIndex = writable<number>(landingIndexInitialState);
 
-export interface InternalCredentialDataModel {
-    id: string;
-    metaInformation: {
-        issuer: string;
-        receivedAt: string;
-    };
-    enrichment: VerifiableCredentialEnrichment | null;
-    credentialDocument: any;
-}
-
-const storedCredentialsInitialState = [];
-export const storedCredentials = writable<InternalCredentialDataModel[]>(storedCredentialsInitialState);
-
-storedCredentials.subscribe(value => {
-    listOfCredentials.update(prev => {
-        if (prev.init) {
-            const idsToDelete = prev.values.filter(id => !value.find(credential => credential.id === id));
-            idsToDelete.map(id => identityService.removeCredential(id));
-            return { ...prev, values: value.map(credential => credential.id) };
-        }
-        return { ...prev, init: true };
-    });
-    value.map(credential => {
-        if (!credential.enrichment) {
-            const enrichment = identityService.enrichCredential(credential.credentialDocument);
-            storedCredentials.update(prev =>
-                prev.map(prevCredential =>
-                    prevCredential.id === credential.id ? { ...prevCredential, enrichment } : prevCredential
-                )
-            );
-        }
-        return identityService.storeCredential(credential.id, credential);
-    });
-});
-
 export const loadingScreen = writable<string | void>();
 
 export function resetAllStores() {
     hasSetupAccount.set(hasSetupAccountInitialState);
-    listOfCredentials.set(listOfCredentialsInitialState);
     credentials.set(credentialsInitialState);
     account.set(accountInitialState);
     modalStatus.set(modalStatusInitialState);
     landingIndex.set(landingIndexInitialState);
-    storedCredentials.set(storedCredentialsInitialState);
     loadingScreen.set();
 }

--- a/identity-enabler/holder-mobile-app/src/lib/ui/helpers.ts
+++ b/identity-enabler/holder-mobile-app/src/lib/ui/helpers.ts
@@ -15,3 +15,13 @@ export async function playAudio(sound: string) {
 
     await audio.play();
 }
+
+/**
+ * Shorten a DID for display.
+ *
+ * @param did DID
+ * @returns Short DID with ellipsis.
+ */
+export function shortenDID(did: string): string {
+    return `${did.substring(0, 15)}...${did.substring(did.length - 6)}`;
+}

--- a/identity-enabler/holder-mobile-app/src/main.ts
+++ b/identity-enabler/holder-mobile-app/src/main.ts
@@ -1,4 +1,7 @@
 import App from "./App.svelte";
+import init from "./lib/init";
+
+init();
 
 const app = new App({
     target: document.body,

--- a/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
@@ -23,18 +23,14 @@
     const preparedCredentialDocument = identityService.prepareCredentialForDisplay(credential);
 
     function createMatrix(content) {
-        try {
-            // The return value is the canvas element
-            bwipjs.toCanvas("presentation", {
-                bcid: "datamatrix",
-                text: content,
-                scale: 3,
-                padding: 20,
-                backgroundcolor: "ffffff"
-            });
-        } catch (e) {
-            console.error(e);
-        }
+        // The return value is the canvas element
+        bwipjs.toCanvas("presentation", {
+            bcid: "datamatrix",
+            text: content,
+            scale: 3,
+            padding: 20,
+            backgroundcolor: "ffffff"
+        });
     }
 
     const addDaysToDate = (date: string, days: number) => {
@@ -43,6 +39,7 @@
         return res.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
     };
 
+    onMount(() => App.addListener("backButton", goBack).remove);
     onMount(async () => {
         loadingScreen.set("Generating DataMatrix...");
 
@@ -55,6 +52,7 @@
             presentationJSON = JSON.stringify(verifiablePresentation, null, 2);
             createMatrix(JSON.stringify(verifiablePresentation));
         } catch (err) {
+            console.error(err);
             await showAlert("Error", "Error creating DataMatrix. Please try again.");
         }
 
@@ -90,8 +88,6 @@
         await wait(MAX_DOUBLE_TAP_DELAY);
         singleTapped = false;
     }
-
-    onMount(() => App.addListener("backButton", goBack).remove);
 
     function shortenDID(did: string): string {
         return `${did.substring(0, 15)}...${did.substring(did.length - 6)}`;

--- a/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
@@ -35,7 +35,11 @@
     const addDaysToDate = (date: string, days: number) => {
         let res = new Date(date);
         res.setDate(res.getDate() + days);
-        return res.toLocaleDateString([...window.navigator.languages], { year: "numeric", month: "long", day: "numeric" });
+        return res.toLocaleDateString([...window.navigator.languages], {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        });
     };
 
     onMount(() => App.addListener("backButton", goBack).remove);

--- a/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
@@ -35,7 +35,7 @@
     const addDaysToDate = (date: string, days: number) => {
         let res = new Date(date);
         res.setDate(res.getDate() + days);
-        return res.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+        return res.toLocaleDateString([...window.navigator.languages], { year: "numeric", month: "long", day: "numeric" });
     };
 
     onMount(() => App.addListener("backButton", goBack).remove);

--- a/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/CreatePresentation.svelte
@@ -8,8 +8,8 @@
     import PresentationJson from "./PresentationJSON.svelte";
     import { Plugins } from "@capacitor/core";
     import { showAlert } from "../lib/ui/helpers";
-    import { IOTA_IDENTITY_RESOLVER } from "../config";
     import type { IdentityService } from "../services/identityService";
+    import CredentialHeader from "../components/CredentialHeader.svelte";
 
     const { App } = Plugins;
     let presentationJSON = "";
@@ -18,9 +18,8 @@
     let singleTapped = false;
     const MAX_DOUBLE_TAP_DELAY = 500;
 
-    const credential = window.history.state.credential.credentialDocument;
+    const credential = window.history.state.credential;
     const identityService = ServiceFactory.get<IdentityService>("identity");
-    const preparedCredentialDocument = identityService.prepareCredentialForDisplay(credential);
 
     function createMatrix(content) {
         // The return value is the canvas element
@@ -88,10 +87,6 @@
         await wait(MAX_DOUBLE_TAP_DELAY);
         singleTapped = false;
     }
-
-    function shortenDID(did: string): string {
-        return `${did.substring(0, 15)}...${did.substring(did.length - 6)}`;
-    }
 </script>
 
 <main>
@@ -106,24 +101,7 @@
             <i on:click={goBack} class="icon-chevron" />
             <i on:click={onClickDev} class="icon-code" />
         </div>
-        <i class="icon-credential credential-logo" />
-        <p>{credential.type[1]}</p>
-        <div class="details">
-            <p>
-                <span
-                    >Subject: <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" target="_blank"
-                        >{shortenDID(credential.credentialSubject.id)}</a
-                    ></span
-                >
-            </p>
-            <p>
-                <span
-                    >Issuer: <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" target="_blank"
-                        >{credential.issuer.name}</a
-                    ></span
-                >
-            </p>
-        </div>
+        <CredentialHeader {credential} hideDetails={true} />
     </header>
 
     <div class="presentation-wrapper">
@@ -131,10 +109,10 @@
     </div>
 
     <footer class="footerContainer">
+        <p>Valid until {addDaysToDate(credential.issuanceDate, 30)}</p>
         {#if credential.type[1] === "Device ID"}
-            <span>Scan this DataMatrix with the Device ID app</span>
+            <p style="font-size: smaller;">Scan this DataMatrix with the Device ID app</p>
         {/if}
-        <p>Valid until {addDaysToDate(preparedCredentialDocument.issuanceDate, 30)}</p>
     </footer>
 </main>
 
@@ -155,43 +133,11 @@
     }
 
     header {
-        margin-bottom: 0;
+        margin-bottom: 1.5rem;
         display: flex;
         flex-direction: column;
         align-items: stretch;
         text-align: center;
-    }
-
-    header > p {
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 700;
-        font-size: 1.25em;
-        color: #fff;
-        margin: 0;
-        padding: 0 2rem;
-    }
-
-    .details {
-        padding: 1rem 2rem;
-    }
-
-    .details > p {
-        font-family: "Proxima Nova", sans-serif;
-        color: #fff;
-        margin: 0.3rem 0;
-    }
-
-    .details a {
-        color: white;
-        font-weight: bold;
-    }
-
-    .details a:visited {
-        color: unset;
-    }
-
-    .credential-logo {
-        font-size: 64px;
     }
 
     .presentation-wrapper {
@@ -209,17 +155,9 @@
 
     footer > p {
         color: #fff;
-        margin: 0;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 500;
         font-size: 1.2em;
-    }
-
-    footer > span {
-        color: #fff;
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 500;
-        font-size: 1em;
     }
 
     .options-wrapper {

--- a/identity-enabler/holder-mobile-app/src/pages/Credential.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/Credential.svelte
@@ -1,19 +1,17 @@
-<script>
+<script lang="ts">
     import { fly } from "svelte/transition";
     import Button from "../components/Button.svelte";
     import ObjectList from "../components/ObjectList.svelte";
     import DevInfo from "./DevInfo.svelte";
     import { modalStatus } from "../lib/store";
-    import { ServiceFactory } from "../factories/serviceFactory";
     import { showAlert } from "../lib/ui/helpers";
     import { onMount } from "svelte";
     import { Plugins } from "@capacitor/core";
+    import CredentialHeader from "../components/CredentialHeader.svelte";
 
     const { App } = Plugins;
     let showTutorial = false;
     const credential = window.history.state.credential;
-    const identityService = ServiceFactory.get("identity");
-    const preparedCredentialDocument = identityService.prepareCredentialForDisplay(credential.credentialDocument);
 
     async function share() {
         if (navigator.onLine === false) {
@@ -30,7 +28,7 @@
 
     function goBack() {
         if ($modalStatus.active) {
-            modalStatus.set({ active: false });
+            modalStatus.set({ active: false, type: null });
             return;
         }
 
@@ -61,19 +59,11 @@
                 <i on:click={onClickDev} class="icon-code" />
             </div>
             <header>
-                {#if credential.enrichment.credentialLabel === "Organisation ID"}
-                    <i class="icon-zebra credential-logo" />
-                    <p>{credential.metaInformation.issuer.toUpperCase()}</p>
-                {:else}
-                    <i class="icon-credential credential-logo" />
-                    <p>{credential.enrichment.issuerLabel}</p>
-                {/if}
-                <p>{credential.enrichment.credentialLabel}</p>
-                <p>{new Date(preparedCredentialDocument.issuanceDate).toLocaleString()}</p>
+                <CredentialHeader {credential} />
             </header>
         </div>
         <section>
-            <ObjectList object={preparedCredentialDocument.credentialSubject} />
+            <ObjectList object={credential.credentialSubject} />
         </section>
         <footer>
             <Button label="Share credential" onClick={share}>
@@ -99,7 +89,7 @@
 
     .header-wrapper {
         text-align: center;
-        padding-bottom: 3vh;
+        padding-bottom: 0.5rem;
         background-color: #00a7ff;
     }
 
@@ -109,30 +99,6 @@
         z-index: 1;
         height: fit-content;
         margin-bottom: 0;
-    }
-
-    header > p {
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 700;
-        font-size: 3.4vh;
-        line-height: 3.4vh;
-        color: #fff;
-    }
-
-    header > p:nth-child(2) {
-        font-weight: 600;
-        text-transform: uppercase;
-        font-size: 1.7vh;
-        line-height: 2.3vh;
-    }
-
-    header > p:nth-child(3) {
-        margin: 1.6vh 0 0 0;
-    }
-
-    header > p:nth-child(4) {
-        margin-bottom: 0;
-        font-size: 1.7vh;
     }
 
     section {
@@ -145,10 +111,6 @@
         width: 100%;
         bottom: 0;
         z-index: 1;
-    }
-
-    .credential-logo {
-        font-size: 64px;
     }
 
     .options-wrapper {

--- a/identity-enabler/holder-mobile-app/src/pages/DeviceCredential.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/DeviceCredential.svelte
@@ -3,7 +3,6 @@
     import { loadingScreen } from "../lib/store";
     import { CredentialType } from "../schemas";
     import { ServiceFactory } from "../factories/serviceFactory";
-    import { generateRandomId } from "../lib/helpers";
     import { showAlert } from "../lib/ui/helpers";
     import Button from "../components/Button.svelte";
     import ObjectList from "../components/ObjectList.svelte";
@@ -30,20 +29,12 @@
             const subjectId = credentialSubject.id;
             const claims = { ...credentialSubject };
             delete claims.id;
-            const newCredential = await identityService.createSignedCredential(
+            const credential = await identityService.createSignedCredential(
                 subjectId,
                 storedIdentity,
                 CredentialType.DEVICE_ID,
                 claims
             );
-            const credentialId = generateRandomId();
-            const enrichment = identityService.enrichCredential({ ...newCredential });
-            const credential = {
-                credentialDocument: { ...newCredential },
-                metaInformation: { issuer: "Zebra Technologies" },
-                id: credentialId,
-                enrichment
-            };
             loadingScreen.set();
             navigate("/createPresentation", { state: { credential } });
         } catch (err) {
@@ -100,10 +91,6 @@
         -webkit-overflow-scrolling: touch;
         position: relative;
         height: 100%;
-    }
-
-    header {
-        margin-bottom: 5vh;
     }
 
     .header-wrapper {

--- a/identity-enabler/holder-mobile-app/src/pages/DeviceCredential.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/DeviceCredential.svelte
@@ -71,7 +71,7 @@
                 <i on:click={onClickDev} class="icon-code" />
             </div>
             <header>
-                <p>Device claims</p>
+                <p>Device Claims</p>
             </header>
         </div>
         <section>
@@ -95,7 +95,6 @@
 
     .header-wrapper {
         text-align: center;
-        padding-bottom: 3vh;
         background-color: #00a7ff;
     }
 
@@ -112,6 +111,7 @@
         font-size: 3.4vh;
         line-height: 3.4vh;
         color: #fff;
+        margin: 0.5rem 0 1.5rem 0;
     }
 
     header > p:nth-child(2) {

--- a/identity-enabler/holder-mobile-app/src/pages/Home.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/Home.svelte
@@ -12,7 +12,7 @@
     import { updateStorage, getFromStorage, account, resetAllStores, loadingScreen } from "../lib/store";
     import { getRandomUserData, wait } from "../lib/helpers";
     import type { IdentityService } from "../services/identityService";
-    import { showAlert } from "../lib/ui/helpers";
+    import { shortenDID, showAlert } from "../lib/ui/helpers";
     import { BACK_BUTTON_EXIT_GRACE_PERIOD } from "../config";
 
     let showTutorial = false;
@@ -170,7 +170,8 @@
                         icon="credential"
                         onClick={() => navigate("/credential", { state: { credential } })}
                         heading={credential.type[1]}
-                        subheading="Issued by {credential.issuer.name}"
+                        subheading="Issued by {credential.issuer.name ??
+                            shortenDID(credential.issuer.id ?? credential.issuer)}"
                     />
                 </div>
             {/each}

--- a/identity-enabler/holder-mobile-app/src/pages/Landing.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/Landing.svelte
@@ -31,8 +31,7 @@
         },
         {
             header: "You control access to your credentials",
-            content:
-                "AppX is all about controlling your credentials. You decide who to share them with.",
+            content: "AppX is all about controlling your credentials. You decide who to share them with.",
             footer: "Next",
             image: "folder.svg"
         }

--- a/identity-enabler/holder-mobile-app/src/pages/PresentationJSON.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/PresentationJSON.svelte
@@ -1,7 +1,7 @@
 <script>
     import Markdown from "../components/Markdown.svelte";
 
-    export let showJSON = Boolean;
+    export let showJSON = true;
     export let code = "";
 
     function onClose() {

--- a/identity-enabler/holder-mobile-app/src/pages/Scan.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/Scan.svelte
@@ -21,6 +21,7 @@
             } catch (e) {
                 console.error(e);
                 navigate("/invalid", { state: { message: "Failed to decode image" } });
+                return;
             }
 
             await handleScannerData(result.getText(), "File");

--- a/identity-enabler/holder-mobile-app/src/schemas/index.ts
+++ b/identity-enabler/holder-mobile-app/src/schemas/index.ts
@@ -6,11 +6,3 @@ export enum CredentialType {
     BLOOD_TEST = "Blood Test",
     DEVICE_ID = "Device ID"
 }
-
-export const DIDMapping: { [DID: string]: { logo: string; issuerLabel: string; theme: string } } = {
-    "did:IOTA:CQMOHTVOCNYQHTSUBSDPNLRBYTBBAHRTOQZZCN9DUWXCVGAYOYGFBEQJOCFXPSCKPPNAZPKALAVYMZICF": {
-        issuerLabel: "Government",
-        logo: "government",
-        theme: "#00ffaa"
-    }
-};

--- a/identity-enabler/holder-mobile-app/src/services/identityService.ts
+++ b/identity-enabler/holder-mobile-app/src/services/identityService.ts
@@ -1,8 +1,8 @@
 import Keychain from "../lib/keychain";
-import { CredentialType, DIDMapping } from "../schemas";
+import type { CredentialType } from "../schemas";
 import { generateRandomNumericString, parse } from "../lib/helpers";
-import { account, InternalCredentialDataModel } from "../lib/store";
-import type { Identity, IdentityConfig, VerifiableCredentialEnrichment } from "../models/types/identity";
+import { account } from "../lib/store";
+import type { Identity, IdentityConfig } from "../models/types/identity";
 import * as IotaIdentity from "@iota/identity-wasm/web";
 import { IDENTITY_WASM_PATH } from "../config";
 import { get } from "svelte/store";
@@ -132,15 +132,6 @@ export class IdentityService {
         }
     }
 
-    retrieveCredentials(ids: string[]): Promise<InternalCredentialDataModel[]> {
-        return Promise.all(ids.map(id => Keychain.get(id)))
-            .then(data => data.map(entry => parse(entry.value)))
-            .catch(e => {
-                console.error(e);
-                return [];
-            });
-    }
-
     /**
      * Creates a signed credential
      *
@@ -204,20 +195,6 @@ export class IdentityService {
         } else {
             return null;
         }
-    }
-
-    /**
-     * Stores credential in keychain
-     *
-     * @method storeCredential
-     *
-     * @param {string} credentialId
-     * @param {VerifiableCredentialDataModel} credential
-     *
-     * @returns {Promise}
-     */
-    storeCredential(credentialId: string, credential: InternalCredentialDataModel): Promise<{ value: boolean }> {
-        return Keychain.set(credentialId, JSON.stringify(credential));
     }
 
     /**
@@ -296,36 +273,5 @@ export class IdentityService {
             console.error("Error during VP Check: " + err);
             return false;
         }
-    }
-
-    enrichCredential(credential: any): VerifiableCredentialEnrichment {
-        const override = DIDMapping[credential.issuer.id];
-        const enrichment = {
-            issuerLabel: override?.issuerLabel ?? "iota", // credential.issuer
-            logo: override?.logo ?? "personal",
-            credentialLabel: credential?.type?.[1],
-            theme: override?.theme ?? "#550000"
-        };
-        return enrichment;
-    }
-
-    prepareCredentialForDisplay(credential: any): any {
-        // TODO: deep copy
-        const copy = { ...credential, credentialSubject: { ...credential.credentialSubject } };
-        // TODO: typing
-        if (copy.credentialSubject.DID) {
-            delete copy.credentialSubject.DID;
-        }
-        return copy;
-    }
-    preparePresentationForDisplay(presentation: any): any {
-        // TODO: deep copy
-        const copy = { ...presentation, verifiableCredential: presentation.verifiableCredential };
-
-        // removes DID entry of presentation array
-        copy.verifiableCredential = copy.verifiableCredential.filter(
-            credential => !(Object.keys(credential.credentialSubject).length === 1 && credential.credentialSubject)
-        );
-        return copy;
     }
 }

--- a/identity-enabler/holder-mobile-app/src/services/identityService.ts
+++ b/identity-enabler/holder-mobile-app/src/services/identityService.ts
@@ -1,10 +1,11 @@
 import Keychain from "../lib/keychain";
 import { CredentialType, DIDMapping } from "../schemas";
 import { generateRandomNumericString, parse } from "../lib/helpers";
-import type { InternalCredentialDataModel } from "../lib/store";
+import { account, InternalCredentialDataModel } from "../lib/store";
 import type { Identity, IdentityConfig, VerifiableCredentialEnrichment } from "../models/types/identity";
 import * as IotaIdentity from "@iota/identity-wasm/web";
 import { IDENTITY_WASM_PATH } from "../config";
+import { get } from "svelte/store";
 
 const {
     Client,
@@ -177,7 +178,10 @@ export class IdentityService {
         const unsignedVc = VerifiableCredential.extend({
             id: `http://example.org/zebra-iota-sdk/${generateRandomNumericString(4)}`,
             type: credentialType,
-            issuer: IssuerDidDoc.id.toString(),
+            issuer: {
+                id: IssuerDidDoc.id.toString(),
+                name: get(account).name
+            },
             credentialSubject
         });
 
@@ -295,7 +299,7 @@ export class IdentityService {
     }
 
     enrichCredential(credential: any): VerifiableCredentialEnrichment {
-        const override = DIDMapping[credential.issuer];
+        const override = DIDMapping[credential.issuer.id];
         const enrichment = {
             issuerLabel: override?.issuerLabel ?? "iota", // credential.issuer
             logo: override?.logo ?? "personal",

--- a/identity-enabler/holder-mobile-app/src/services/identityService.ts
+++ b/identity-enabler/holder-mobile-app/src/services/identityService.ts
@@ -198,34 +198,6 @@ export class IdentityService {
     }
 
     /**
-     * Remove credential from keychain
-     *
-     * @method removeCredential
-     *
-     * @param {string} credentialId
-     *
-     * @returns {Promise}
-     */
-    removeCredential(credentialId: string): Promise<{ value: boolean }> {
-        return Keychain.remove(credentialId);
-    }
-
-    /**
-     * Retrieves credential from keychain
-     *
-     * @method retrieveCredential
-     *
-     * @param {string} credentialId
-     *
-     * @returns {Promise}
-     */
-    retrieveCredential(credentialId: string): Promise<IotaIdentity.VerifiableCredential> {
-        return Keychain.get(credentialId)
-            .then(async data => parse(data.value))
-            .catch(() => null);
-    }
-
-    /**
      * Creates verifiable presentations for provided schema names
      *
      * @method createVerifiablePresentations

--- a/identity-enabler/verifier-mobile-app/rollup.config.js
+++ b/identity-enabler/verifier-mobile-app/rollup.config.js
@@ -14,6 +14,27 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
+function serve() {
+    let server;
+
+    function toExit() {
+        if (server) server.kill(0);
+    }
+
+    return {
+        writeBundle() {
+            if (server) return;
+            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
+                stdio: ["ignore", "inherit", "inherit"],
+                shell: true
+            });
+
+            process.on("SIGTERM", toExit);
+            process.on("exit", toExit);
+        }
+    };
+}
+
 export default {
     input: "src/main.ts",
     output: {
@@ -73,6 +94,9 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
+        // In dev mode, call `npm run start` once
+        // the bundle has been generated
+        !production && serve(),
 
         // Watch the `public` directory and refresh the
         // browser on changes when not in production

--- a/identity-enabler/verifier-mobile-app/rollup.config.js
+++ b/identity-enabler/verifier-mobile-app/rollup.config.js
@@ -14,27 +14,6 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
-function serve() {
-    let server;
-
-    function toExit() {
-        if (server) server.kill(0);
-    }
-
-    return {
-        writeBundle() {
-            if (server) return;
-            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
-                stdio: ["ignore", "inherit", "inherit"],
-                shell: true
-            });
-
-            process.on("SIGTERM", toExit);
-            process.on("exit", toExit);
-        }
-    };
-}
-
 export default {
     input: "src/main.ts",
     output: {
@@ -94,9 +73,6 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
-        // In dev mode, call `npm run start` once
-        // the bundle has been generated
-        !production && serve(),
 
         // Watch the `public` directory and refresh the
         // browser on changes when not in production

--- a/identity-enabler/verifier-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/verifier-mobile-app/src/components/CredentialHeader.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+    import { IOTA_IDENTITY_RESOLVER } from "../config";
+    import { isExpired } from "../lib/helpers";
+    import { shortenDID } from "../lib/ui/helpers";
+
+    export let credential;
+    export let color = "white";
+    export let hideDetails = false;
+
+    let expired = isExpired(credential.issuanceDate);
+</script>
+
+<div id="wrapper" style="color: {color};">
+    {#if !expired}
+        <i class="icon-check" />
+        <h2>VALID CREDENTIAL</h2>
+    {:else}
+        <i class="icon-cross" />
+        <h2>EXPIRED CREDENTIAL</h2>
+    {/if}
+    {#if !hideDetails}
+        <p>
+            <span>Issued to </span>
+            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" class="emphasis" target="_blank">
+                {shortenDID(credential.credentialSubject.id)}
+            </a>
+            <span> by </span>
+            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" class="emphasis" target="_blank"
+                >{credential.issuer.name}
+            </a>
+            <span> at </span>
+            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString()}</span>
+        </p>
+    {/if}
+</div>
+
+<style>
+    #wrapper {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 0 2rem;
+        font-family: "Proxima Nova", sans-serif;
+    }
+
+    i {
+        color: inherit;
+        font-size: 64px;
+    }
+
+    h2 {
+        margin: 0;
+        font-size: 1.2em;
+    }
+
+    p {
+        line-height: 1.5em;
+        margin-bottom: 0;
+    }
+
+    p .emphasis {
+        font-weight: bold;
+        padding: 0 0.2rem;
+    }
+
+    a {
+        color: inherit;
+    }
+
+    a:visited {
+        color: unset;
+    }
+</style>

--- a/identity-enabler/verifier-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/verifier-mobile-app/src/components/CredentialHeader.svelte
@@ -20,16 +20,17 @@
     {/if}
     {#if !hideDetails}
         <p>
-            <span>Issued to </span>
-            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.credentialSubject.id}" class="emphasis" target="_blank">
-                {shortenDID(credential.credentialSubject.id)}
-            </a>
-            <span> by </span>
-            <a href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id}" class="emphasis" target="_blank"
-                >{credential.issuer.name}
+            <span>Issued by </span>
+            <a
+                href="{IOTA_IDENTITY_RESOLVER}/{credential.issuer.id ?? credential.issuer}"
+                class="emphasis"
+                target="_blank"
+                >{credential.issuer.name ?? shortenDID(credential.issuer.id ?? credential.issuer)}
             </a>
             <span> at </span>
-            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span>
+            <span class="emphasis"
+                >{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span
+            >
         </p>
     {/if}
 </div>

--- a/identity-enabler/verifier-mobile-app/src/components/CredentialHeader.svelte
+++ b/identity-enabler/verifier-mobile-app/src/components/CredentialHeader.svelte
@@ -29,7 +29,7 @@
                 >{credential.issuer.name}
             </a>
             <span> at </span>
-            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString()}</span>
+            <span class="emphasis">{new Date(credential.issuanceDate).toLocaleString([...window.navigator.languages])}</span>
         </p>
     {/if}
 </div>

--- a/identity-enabler/verifier-mobile-app/src/components/ListItem.svelte
+++ b/identity-enabler/verifier-mobile-app/src/components/ListItem.svelte
@@ -1,7 +1,7 @@
 <script type="ts">
     export let onClick;
-    export let heading: string | undefined = undefined;
-    export let subheading: string;
+    export let heading: string;
+    export let subheading: string | undefined = undefined;
     export let icon: string = "credential";
     export let iconColor: string = "black";
     export let arrow = true;
@@ -10,14 +10,14 @@
 <li on:click={onClick}>
     <i class="icon-{icon}" style="color: {iconColor};" />
     <div class="text-container">
-        {#if heading}
+        <div class="overflow-container">
+            <h5>{heading}</h5>
+        </div>
+        {#if subheading}
             <div class="overflow-container">
-                <h5>{heading}</h5>
+                <h6>{subheading}</h6>
             </div>
         {/if}
-        <div class="overflow-container">
-            <h6>{subheading}</h6>
-        </div>
     </div>
     {#if arrow}
         <i class="icon-chevron rotate-180" />
@@ -59,19 +59,16 @@
         display: inline;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
-        font-size: 0.75em;
-        letter-spacing: 0.06em;
-        color: #8593ac;
-        text-transform: uppercase;
-        margin: 0 0 0.9vh 0;
+        font-size: 1em;
+        margin: 0;
     }
 
     h6 {
         display: inline;
         font-family: "Proxima Nova", sans-serif;
         font-weight: 600;
-        font-size: 1em;
+        font-size: 0.75em;
         margin: 0;
-        color: #051923;
+        color: #8593ac;
     }
 </style>

--- a/identity-enabler/verifier-mobile-app/src/config.ts
+++ b/identity-enabler/verifier-mobile-app/src/config.ts
@@ -6,10 +6,6 @@ export const IOTA_NODE_URL = "https://chrysalis-nodes.iota.org";
 
 export const IOTA_PERMANODE_URL = "https://chrysalis-chronicle.iota.org/api/mainnet/";
 
-export const DEFAULT_LANGUAGE = "English";
-
-export const DEFAULT_LOCALE = "en";
-
 export const TUTORIAL_BASE_URL = "https://zebradevs.github.io/Zebra-Iota-Edge-SDK/docs";
 
 export const IDENTITY_WASM_PATH = "/wasm/identity_wasm_bg.wasm";

--- a/identity-enabler/verifier-mobile-app/src/lib/store.ts
+++ b/identity-enabler/verifier-mobile-app/src/lib/store.ts
@@ -1,6 +1,5 @@
 import { writable } from "svelte/store";
 import { persistent } from "./helpers";
-import type { VerifiableCredentialEnrichment } from "../models/types/identity";
 
 export const updateStorage = async (key, value) => {
     try {
@@ -38,16 +37,6 @@ export const credentials = persistent<{ personal: string; health: string; blood:
 });
 
 export const loadingScreen = writable<string | void>();
-
-export interface InternalCredentialDataModel {
-    id: string;
-    metaInformation: {
-        issuer: string;
-        receivedAt: string;
-    };
-    enrichment: VerifiableCredentialEnrichment | null;
-    credentialDocument: any;
-}
 
 /**
  * Error string

--- a/identity-enabler/verifier-mobile-app/src/lib/store.ts
+++ b/identity-enabler/verifier-mobile-app/src/lib/store.ts
@@ -1,9 +1,6 @@
 import { writable } from "svelte/store";
 import { persistent } from "./helpers";
-import init from "./init";
 import type { VerifiableCredentialEnrichment } from "../models/types/identity";
-
-init();
 
 export const updateStorage = async (key, value) => {
     try {

--- a/identity-enabler/verifier-mobile-app/src/lib/ui/helpers.ts
+++ b/identity-enabler/verifier-mobile-app/src/lib/ui/helpers.ts
@@ -15,3 +15,13 @@ export async function playAudio(sound: string) {
 
     await audio.play();
 }
+
+/**
+ * Shorten a DID for display.
+ *
+ * @param did DID
+ * @returns Short DID with ellipsis.
+ */
+export function shortenDID(did: string): string {
+    return `${did.substring(0, 15)}...${did.substring(did.length - 6)}`;
+}

--- a/identity-enabler/verifier-mobile-app/src/main.ts
+++ b/identity-enabler/verifier-mobile-app/src/main.ts
@@ -1,4 +1,7 @@
 import App from "./App.svelte";
+import init from "./lib/init";
+
+init();
 
 const app = new App({
     target: document.body,

--- a/identity-enabler/verifier-mobile-app/src/models/types/identity.ts
+++ b/identity-enabler/verifier-mobile-app/src/models/types/identity.ts
@@ -15,10 +15,3 @@ export type IdentityConfig = {
     network: string;
     permanode?: string;
 };
-
-export type VerifiableCredentialEnrichment = {
-    issuerLabel: string;
-    logo: string;
-    credentialLabel: string;
-    theme: string;
-};

--- a/identity-enabler/verifier-mobile-app/src/pages/Credential.svelte
+++ b/identity-enabler/verifier-mobile-app/src/pages/Credential.svelte
@@ -67,7 +67,7 @@
             <ObjectList object={credential.credentialSubject} />
         </section>
         <footer>
-            <Button label="Done" onClick={() => navigate("/home")} />
+            <Button label="Done" onClick={onDone} />
         </footer>
     {/if}
 </main>
@@ -92,10 +92,6 @@
         background-color: #6165e3;
     }
 
-    header > i {
-        font-size: 64px;
-    }
-
     .header-wrapper.expired {
         background-color: black;
     }
@@ -106,15 +102,6 @@
         z-index: 1;
         height: fit-content;
         margin-bottom: 0;
-    }
-
-    header > p {
-        font-family: "Proxima Nova", sans-serif;
-        font-weight: 600;
-        font-size: 1.9vh;
-        line-height: 3.4vh;
-        color: #fff;
-        margin: 0;
     }
 
     section {

--- a/identity-enabler/verifier-mobile-app/src/pages/Credential.svelte
+++ b/identity-enabler/verifier-mobile-app/src/pages/Credential.svelte
@@ -8,6 +8,7 @@
     import { isExpired } from "../lib/helpers";
     import { navigate } from "svelte-routing";
     import { onMount } from "svelte";
+    import CredentialHeader from "../components/CredentialHeader.svelte";
 
     const { App, Modals } = Plugins;
 
@@ -59,13 +60,7 @@
                 <i on:click={onClickDev} class="icon-code" />
             </div>
             <header>
-                {#if !expired}
-                    <i class="icon-check" />
-                    <p>VALID CREDENTIAL</p>
-                {:else}
-                    <i class="icon-cross" />
-                    <p>EXPIRED CREDENTIAL</p>
-                {/if}
+                <CredentialHeader {credential} />
             </header>
         </div>
         <section>

--- a/identity-enabler/verifier-mobile-app/src/pages/Home.svelte
+++ b/identity-enabler/verifier-mobile-app/src/pages/Home.svelte
@@ -9,7 +9,7 @@
     import Button from "../components/Button.svelte";
     import ListItem from "../components/ListItem.svelte";
     import DevInfo from "./DevInfo.svelte";
-    import { showAlert } from "../lib/ui/helpers";
+    import { showAlert, shortenDID } from "../lib/ui/helpers";
     import { BACK_BUTTON_EXIT_GRACE_PERIOD } from "../config";
 
     const { App, Toast, Modals } = Plugins;
@@ -128,7 +128,8 @@
                             iconColor="#1e22aa"
                             onClick={() => onClickCredential(credential)}
                             heading={credential.type[1]}
-                            subheading="Issued by {credential.issuer.name}"
+                            subheading="Issued by {credential.issuer.name ??
+                                shortenDID(credential.issuer.id ?? credential.issuer)}"
                         />
                     </div>
                 {/each}

--- a/identity-enabler/verifier-mobile-app/src/pages/Home.svelte
+++ b/identity-enabler/verifier-mobile-app/src/pages/Home.svelte
@@ -29,7 +29,7 @@
             isEmpty = Object.values(localCredentials).every(x => x === null || x === "");
             loading = false;
         } catch (err) {
-            console.log(err);
+            console.error(err);
             loading = false;
         }
     });
@@ -127,9 +127,8 @@
                             icon={isExpired(credential.issuanceDate) ? "cross" : "check"}
                             iconColor="#1e22aa"
                             onClick={() => onClickCredential(credential)}
-                            heading={"IOTA"}
-                            subheading={credential.type[1]}
-                            expired={isExpired(credential.issuanceDate)}
+                            heading={credential.type[1]}
+                            subheading="Issued by {credential.issuer.name}"
                         />
                     </div>
                 {/each}

--- a/identity-enabler/verifier-mobile-app/src/schemas/index.ts
+++ b/identity-enabler/verifier-mobile-app/src/schemas/index.ts
@@ -1,7 +1,0 @@
-export const DIDMapping: { [DID: string]: { logo: string; issuerLabel: string; theme: string } } = {
-    "did:IOTA:CQMOHTVOCNYQHTSUBSDPNLRBYTBBAHRTOQZZCN9DUWXCVGAYOYGFBEQJOCFXPSCKPPNAZPKALAVYMZICF": {
-        issuerLabel: "Government",
-        logo: "government",
-        theme: "#00ffaa"
-    }
-};

--- a/identity-enabler/verifier-mobile-app/src/services/identityService.ts
+++ b/identity-enabler/verifier-mobile-app/src/services/identityService.ts
@@ -1,8 +1,6 @@
 import Keychain from "../lib/keychain";
-import { DIDMapping } from "../schemas";
 import { parse } from "../lib/helpers";
-import type { InternalCredentialDataModel } from "../lib/store";
-import type { Identity, IdentityConfig, VerifiableCredentialEnrichment } from "../models/types/identity";
+import type { Identity, IdentityConfig } from "../models/types/identity";
 import * as IotaIdentity from "@iota/identity-wasm/web";
 import { IDENTITY_WASM_PATH } from "../config";
 
@@ -116,57 +114,6 @@ export class IdentityService {
             .catch(() => null);
     }
 
-    retrieveCredentials(ids: string[]): Promise<InternalCredentialDataModel[]> {
-        return Promise.all(ids.map(id => Keychain.get(id)))
-            .then(data => data.map(entry => parse(entry.value)))
-            .catch(e => {
-                console.error(e);
-                return [];
-            });
-    }
-
-    /**
-     * Stores credential in keychain
-     *
-     * @method storeCredential
-     *
-     * @param {string} credentialId
-     * @param {VerifiableCredentialDataModel} credential
-     *
-     * @returns {Promise}
-     */
-    storeCredential(credentialId: string, credential: InternalCredentialDataModel): Promise<{ value: boolean }> {
-        return Keychain.set(credentialId, JSON.stringify(credential));
-    }
-
-    /**
-     * Remove credential from keychain
-     *
-     * @method removeCredential
-     *
-     * @param {string} credentialId
-     *
-     * @returns {Promise}
-     */
-    removeCredential(credentialId: string): Promise<{ value: boolean }> {
-        return Keychain.remove(credentialId);
-    }
-
-    /**
-     * Retrieves credential from keychain
-     *
-     * @method retrieveCredential
-     *
-     * @param {string} credentialId
-     *
-     * @returns {Promise}
-     */
-    retrieveCredential(credentialId: string): Promise<IotaIdentity.VerifiableCredential> {
-        return Keychain.get(credentialId)
-            .then(async data => parse(data.value))
-            .catch(() => null);
-    }
-
     /**
      * Creates verifiable presentations for provided schema names
      *
@@ -215,17 +162,6 @@ export class IdentityService {
             console.error("Error during VP Check: " + err);
             return false;
         }
-    }
-
-    enrichCredential(credential: any): VerifiableCredentialEnrichment {
-        const override = DIDMapping[credential.issuer];
-        const enrichment = {
-            issuerLabel: override?.issuerLabel ?? "iota", // credential.issuer
-            logo: override?.logo ?? "personal",
-            credentialLabel: credential?.type?.[1],
-            theme: override?.theme ?? "#550000"
-        };
-        return enrichment;
     }
 
     prepareCredentialForDisplay(credential: any): any {


### PR DESCRIPTION
- Closes https://github.com/ZebraDevs/Zebra-Iota-Edge-SDK/issues/26
- Moves init call to main.ts (new changes causes cyclical import in holder app)
- Adds a new component reusable CredentialHeader to each app 
- Removes redundant code in Holder app (**note**: impacts structure of data in LocalStorage - not compatible with previous persistence format, please clear LocalStorage)