### PR TITLE
persist name only if identity was successfully created

### DIFF
--- a/identity-enabler/deviceId-mobile-app/src/pages/Name.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/Name.svelte
@@ -29,7 +29,6 @@
         }
 
         Keyboard.hide();
-        account.set({ name: name });
         loadingScreen.set("Creating Identity...");
         const identityService = ServiceFactory.get("identity");
         let identity;
@@ -40,8 +39,10 @@
             console.error(err);
             loadingScreen.set();
             await showAlert("Error", `Error creating identity: ${err.message}`);
+            return;
         }
 
+        account.set({ name: name });
         await identityService.storeIdentity("did", identity);
         hasSetupAccount.set(true);
         loadingScreen.set();

--- a/identity-enabler/deviceId-mobile-app/src/pages/Name.svelte
+++ b/identity-enabler/deviceId-mobile-app/src/pages/Name.svelte
@@ -42,8 +42,8 @@
             return;
         }
 
-        account.set({ name: name });
         await identityService.storeIdentity("did", identity);
+        account.set({ name });
         hasSetupAccount.set(true);
         loadingScreen.set();
         navigate("/home");

--- a/identity-enabler/holder-mobile-app/src/pages/Name.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/Name.svelte
@@ -43,8 +43,8 @@
             return;
         }
 
-        account.set({ name: name });
         await identityService.storeIdentity("did", identity);
+        account.set({ name });
         hasSetupAccount.set(true);
         loadingScreen.set();
         navigate("/home");

--- a/identity-enabler/holder-mobile-app/src/pages/Name.svelte
+++ b/identity-enabler/holder-mobile-app/src/pages/Name.svelte
@@ -30,7 +30,6 @@
         }
 
         Keyboard.hide();
-        account.set({ name: name });
         loadingScreen.set("Creating Identity...");
         const identityService = ServiceFactory.get("identity");
         let identity;
@@ -44,6 +43,7 @@
             return;
         }
 
+        account.set({ name: name });
         await identityService.storeIdentity("did", identity);
         hasSetupAccount.set(true);
         loadingScreen.set();


### PR DESCRIPTION
* Return during identity creation error block in device id app
* Only save name if identity generation was successful