### PR TITLE
do not serve as part of build

### DIFF
--- a/identity-enabler/deviceId-mobile-app/rollup.config.js
+++ b/identity-enabler/deviceId-mobile-app/rollup.config.js
@@ -14,27 +14,6 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
-function serve() {
-    let server;
-
-    function toExit() {
-        if (server) server.kill(0);
-    }
-
-    return {
-        writeBundle() {
-            if (server) return;
-            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
-                stdio: ["ignore", "inherit", "inherit"],
-                shell: true
-            });
-
-            process.on("SIGTERM", toExit);
-            process.on("exit", toExit);
-        }
-    };
-}
-
 export default {
     input: "src/main.ts",
     output: {
@@ -98,9 +77,6 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
-        // In dev mode, call `npm run start` once
-        // the bundle has been generated
-        !production && serve(),
 
         // Watch the `public` directory and refresh the
         // browser on changes when not in production

--- a/identity-enabler/holder-mobile-app/rollup.config.js
+++ b/identity-enabler/holder-mobile-app/rollup.config.js
@@ -14,27 +14,6 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
-function serve() {
-    let server;
-
-    function toExit() {
-        if (server) server.kill(0);
-    }
-
-    return {
-        writeBundle() {
-            if (server) return;
-            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
-                stdio: ["ignore", "inherit", "inherit"],
-                shell: true
-            });
-
-            process.on("SIGTERM", toExit);
-            process.on("exit", toExit);
-        }
-    };
-}
-
 export default {
     input: "src/main.ts",
     output: {
@@ -98,9 +77,6 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
-        // In dev mode, call `npm run start` once
-        // the bundle has been generated
-        !production && serve(),
 
         // Watch the `public` directory and refresh the
         // browser on changes when not in production

--- a/identity-enabler/verifier-mobile-app/rollup.config.js
+++ b/identity-enabler/verifier-mobile-app/rollup.config.js
@@ -14,27 +14,6 @@ import * as path from "path";
 
 const production = !process.env.ROLLUP_WATCH;
 
-function serve() {
-    let server;
-
-    function toExit() {
-        if (server) server.kill(0);
-    }
-
-    return {
-        writeBundle() {
-            if (server) return;
-            server = require("child_process").spawn("npm", ["run", "start", "--", "--dev"], {
-                stdio: ["ignore", "inherit", "inherit"],
-                shell: true
-            });
-
-            process.on("SIGTERM", toExit);
-            process.on("exit", toExit);
-        }
-    };
-}
-
 export default {
     input: "src/main.ts",
     output: {
@@ -98,9 +77,6 @@ export default {
             sourceMap: !production,
             inlineSources: !production
         }),
-        // In dev mode, call `npm run start` once
-        // the bundle has been generated
-        !production && serve(),
 
         // Watch the `public` directory and refresh the
         // browser on changes when not in production


### PR DESCRIPTION
Removes rollup config that when running `npm run build:dev` would cause a server to be created. 

This way, `build:dev` watches source files for changes and rebuilds while `start:dev` watches `public` directory for changes and restarts.